### PR TITLE
Restructure and add oscillator fixing to POST

### DIFF
--- a/firmware/api.h
+++ b/firmware/api.h
@@ -35,5 +35,17 @@
 
 //Standalone functions.
 
+typedef struct post_status {
+  uint8_t failed: 1;  // Have any tests failed?
+  uint8_t lcd_bad: 1;
+  uint8_t crystal_bad: 1;
+  uint8_t rf_low_vcore: 1;
+  uint8_t rf_operand_err: 1;
+  uint8_t rf_out_data_err: 1;
+  uint8_t rf_operand_overrite_err: 1;
+} post_status;
+
 //! Power On Self Test
-int post();
+post_status post();
+
+void display_post(post_status status);

--- a/firmware/apps/clock.c
+++ b/firmware/apps/clock.c
@@ -282,7 +282,7 @@ void clock_draw(){
     case '7':
       //Hold 7 to run the self-test after startup.  Response codes try to
       //roughly describe the fault.
-      post();
+      display_post(post());
       break;
     case '8':
       //8 shows the callsign.


### PR DESCRIPTION
This splits apart the POST testing from the displaying of the results. The POST now will clear the relevant fault flags. If it detects an oscillator problem it should try to reinitialize the oscillator. This will close #41.

@travisgoodspeed Does the POST need to call some of the UCS functions here to reinitialize the oscillator?
https://github.com/travisgoodspeed/goodwatch/compare/POST-improvements?expand=1#diff-f5275649d3fca868896862b40f4f317cR43