### PR TITLE
Fix typo in data percent warning message

### DIFF
--- a/bin/printsizes.py
+++ b/bin/printsizes.py
@@ -37,7 +37,7 @@ def printsizes(stream):
     print("%d bytes of .data, %d bytes of .bss, %d bytes of .noinit (%d %%)"
           %(datalen,bsslen,noinitlen,dataperc));
     if dataperc>80:
-        print("WARNING: %d percent of code is used!"%codeperc);
+        print("WARNING: %d percent of data is used!"%dataperc);
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a minor typo: printsizes.py prints a warning on code and/or data size but the warning messages are both reporting code size 