### PR TITLE
Addressing #67 - RNG now has more uniform distribution

### DIFF
--- a/firmware/rng.c
+++ b/firmware/rng.c
@@ -43,8 +43,10 @@ unsigned int true_rand(void) {
     seed <<= 1;  
     if (ones >= 3) //majority of 5 samples 
       seed |= 1;
-    UCSCTL1 += 5; // update DCORSEL to change speed
-    UCSCTL5 ^= ((seed & 3) << 8); // update ALCK divider
+    // even though SLA338 recomends changing dividers and speed to increase 
+    // uniformity, tests have shown better results with these two lines disabled
+    //UCSCTL1 += 5; // update DCORSEL to change speed
+    //UCSCTL5 ^= ((seed & 3) << 8); // update ALCK divider
   }
 
   // restore everything we've been messing with


### PR DESCRIPTION
Counterintuitively, removing the code that changes deviders and speed
makes for a more uniform output.

Review and close related issue if ok.