### PR TITLE
add marquee, implement for dow

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -67,8 +67,8 @@ CC = msp430-gcc -mmcu=cc430f6137 -Wall -I. -Os  $(addprefix -D, $(APPS_DEFINES))
 
 BSL = ../bin/cc430-bsl.py -r 38400 -p $(PORT)
 
-modules=rtcasm.o main.o lcd.o lcdtext.o rtc.o  keypad.o apps.o applist.o \
-	sidebutton.o power.o uart.o monitor.o ucs.o buzz.o \
+modules=rtcasm.o main.o lcd.o lcdtext.o marquee.o rtc.o keypad.o apps.o \
+	applist.o sidebutton.o power.o uart.o monitor.o ucs.o buzz.o \
 	radio.o packet.o dmesg.o codeplug.o rng.o descriptor.o \
 	libs/assembler.o libs/morse.o 
 

--- a/firmware/api.h
+++ b/firmware/api.h
@@ -18,6 +18,7 @@
 #include "monitor.h"
 #include "ucs.h"
 #include "lcdtext.h"
+#include "marquee.h"
 #include "keypad.h"
 #include "apps.h"
 #include "rtc.h"

--- a/firmware/apps/clock.c
+++ b/firmware/apps/clock.c
@@ -71,19 +71,14 @@ static void draw_date(){
 }
 
 static const char *daysofweek[7]={
-  "  sunday",
-  "  monday",
-  " tuesday",
-  "wednesdy",
-  "thursday",
-  "  friday",
-  "saturday"
+  " sunday ",
+  " monday ",
+  " tuesday ",
+  " wednesday ",
+  " thursday ",
+  " friday ",
+  " saturday "
 };
-
-//! Draws the day of the week.
-static void draw_dow(){
-  lcd_string(daysofweek[RTCDOW]);
-}
 
 //! Draws the date as yyyy.mm.dd
 static void draw_date_rom(){
@@ -235,10 +230,6 @@ void clock_draw(){
       lcd_string("        ");
       lcd_string(CALLSIGN);
       break;
-    case '9':
-      //Hold 9 to draw the day of the week.
-      draw_dow();
-      break;
     case '/':
       //Hold / to draw the date.
       draw_date();
@@ -263,6 +254,7 @@ void clock_draw(){
       setperiod(5,1);
       setperiod(2,1);
       break;
+    case '9':
     case 0:
       // Draw the time by default.
       draw_time();
@@ -360,11 +352,15 @@ int clock_keypress(char ch){
     //Update the DOW.  We could save some cycles by only doing this if
     //the date changes, but we don't bother.
     rtc_setdow();
-  }else{
-    switch(ch){
+
+  } else {
+    switch (ch) {
     case '6':
       //6 toggles the CPU load indicator.
       flickermode=(flickermode?0:-1);
+      break;
+    case '9':
+      marquee(daysofweek[RTCDOW]);
       break;
     }
   }

--- a/firmware/lcd.c
+++ b/firmware/lcd.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 
 #include "api.h"
-#include "marquee.h"
 
 //! LCD Main memory.
 volatile unsigned char *lcdm=&LCDM1;

--- a/firmware/lcd.c
+++ b/firmware/lcd.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include "api.h"
+#include "marquee.h"
 
 //! LCD Main memory.
 volatile unsigned char *lcdm=&LCDM1;
@@ -95,6 +96,9 @@ void lcd_postdraw(){
   }
   if(power_ishigh())
     setminus(1);    //Minus indicates the radio is on.
+
+  // display marquee, if active
+  draw_marquee();
   
   //Now swap back the buffer.
   LCDBMEMCTL &= ~LCDDISP; // Return to main display memory.

--- a/firmware/marquee.c
+++ b/firmware/marquee.c
@@ -40,8 +40,14 @@ void draw_marquee(void)
     if (!marquee_len) return;
 
     int i;
-    for (i = 0; i < MIN(marquee_len, marquee_startdigit + 1); i++)
-        lcd_char(marquee_startdigit - i, marquee_buf[marquee_skip + i]);
+    int digit;
+    for (i = 0; i < MIN(marquee_len, marquee_startdigit + 1); i++) {
+        digit = marquee_startdigit - i;
+        lcd_char(digit, marquee_buf[marquee_skip + i]);
+        setperiod(digit, 0);
+        if (digit == 5)
+            setcolon(0);
+    }
 
     if (marquee_startdigit != 7) {
         marquee_startdigit++;

--- a/firmware/marquee.c
+++ b/firmware/marquee.c
@@ -1,0 +1,52 @@
+/*! \file marquee.c
+  \brief Scroll text on screen atop LCD contents.
+  Blame qguv for all bugs in this module.
+*/
+
+#include <string.h>
+
+#include "lcdtext.h"
+
+static char marquee_buf[32];
+static int marquee_len = 0;
+static int marquee_startdigit;
+static int marquee_skip;
+
+#define MIN(X, Y) ((Y) < (X) ? (Y) : (X))
+
+/*! Set the marquee to be drawn atop whatever's on the LCD.
+    If a marquee is already going, it will be replaced. */
+void marquee(const char * const s)
+{
+    marquee_len = strlen(s);
+    if (marquee_len > (int) sizeof(marquee_buf))
+        marquee_len = sizeof(marquee_buf);
+
+    memcpy(marquee_buf, s, marquee_len);
+
+    marquee_startdigit = 0;
+    marquee_skip = 0;
+}
+
+//! Disable a running marquee
+void stop_marquee(void)
+{
+    marquee_len = 0;
+}
+
+//! Blit the marquee to the screen (called by LCD module)
+void draw_marquee(void)
+{
+    if (!marquee_len) return;
+
+    int i;
+    for (i = 0; i < MIN(marquee_len, marquee_startdigit + 1); i++)
+        lcd_char(marquee_startdigit - i, marquee_buf[marquee_skip + i]);
+
+    if (marquee_startdigit != 7) {
+        marquee_startdigit++;
+    } else {
+        marquee_skip++;
+        marquee_len--;
+    }
+}

--- a/firmware/marquee.h
+++ b/firmware/marquee.h
@@ -1,0 +1,14 @@
+/*! \file marquee.h
+  \brief Scroll text on screen atop LCD contents.
+  Blame qguv for all bugs in this module.
+*/
+
+/*! Set the marquee to be drawn atop whatever's on the LCD.
+    If a marquee is already going, it will be replaced. */
+void marquee(const char * const s);
+
+//! Disable a running marquee
+void stop_marquee(void);
+
+//! Blit the marquee to the screen (called by LCD module)
+void draw_marquee(void);


### PR DESCRIPTION
This PR introduces a marquee that displays over the current LCD contents when the marquee buffer is populated by calling a `marquee()` function with the desired text. I'm now using it to show the weekday in the clock app. Here's [a demo](https://ptpb.pw/ANsbweoMnb1cK7QpqdHTnUayKEgo.gif)!