### PR TITLE
clock: add label for cpu load toggle button

### DIFF
--- a/firmware/apps/clock.c
+++ b/firmware/apps/clock.c
@@ -225,6 +225,11 @@ void clock_draw(){
     draw_settingtime();
   else
     switch(ch){
+    case '6':
+      lcd_string("CPU LOAD");
+      setplus(!!flickermode);
+      setminus(!flickermode);
+      break;
     case '7':
       //Hold 7 to run the self-test after startup.  Response codes try to
       //roughly describe the fault.


### PR DESCRIPTION
Displays `CPU LOAD` when CPU load is toggled, along with `-` or `+` depending on whether you're enabling or disabling the indicator. Here's [a demo](https://ptpb.pw/AJbMrZd0yh9NR6md8bSiH6rkEIgN.gif)!