### PR TITLE
clock: suppress hex keycode when toggling CPU load indicator

### DIFF
--- a/firmware/apps/clock.c
+++ b/firmware/apps/clock.c
@@ -263,6 +263,7 @@ void clock_draw(){
       setperiod(5,1);
       setperiod(2,1);
       break;
+    case '6':
     case 0:
       // Draw the time by default.
       draw_time();


### PR DESCRIPTION
When clock keypad buttons aren't used for a feature, they show the keycode in hex when held. Pressing `6` to toggle the CPU load indicator showed a keycode while it's held as if it were an unused button. This PR suppresses that.