### PR TITLE
Update Makefile with more of the MSP430-elf tools

### DIFF
--- a/firmware/Makefile.gcc7
+++ b/firmware/Makefile.gcc7
@@ -112,7 +112,7 @@ goodwatch.elf: $(modules) $(apps) *.h
 	../bin/printsizes.py goodwatch.elf || echo "Please install python-pyelftools."
 
 goodwatch.hex: goodwatch.elf
-	msp430-objcopy -O ihex goodwatch.elf goodwatch.hex
+	msp430-elf-objcopy -O ihex goodwatch.elf goodwatch.hex
 
 clean:
 	rm -rf *~ */*~ *.hex *.elf *.o */*.o goodwatch githash.h buildtime.h html latex goodwatch.elf energytrace.png energytrace.txt codeplugstr.c dmesg.bin


### PR DESCRIPTION
This is a minor change to make the gcc7 makefile referenced in #119 utilize the corresponding objcopy utility. 

