### PR TITLE
Print the git hash of the firmware on boot

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -107,6 +107,7 @@ all: goodwatch.hex
 
 githash.h:
 	echo "#define GITHASH" 0x`git rev-parse HEAD | head -c7` > githash.h
+	echo "#define GITHASH_STR \"`git rev-parse HEAD | head -c7`\"" >> githash.h
 buildtime.h:
 	../bin/buildtime.py >buildtime.h
 

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -64,6 +64,8 @@ int main(void) {
   //Initialize the various modules.
   dmesg_init();
 
+  printf("Firmware git version %s\n", GITHASH_STR);
+
   printf("RNG ");
   srand(true_rand()); // we do this as early as possible, because it messes with clocks
 


### PR DESCRIPTION
This is helpful to make sure that that the right firmware is flashed before assembling the watch, only to realize that the wrong firmware version was flashed.