### PR TITLE
Python3 harder for goodwatch.py

### DIFF
--- a/bin/goodwatch.py
+++ b/bin/goodwatch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 ## This is a quick and dirty python client for communicating with a
 ## GoodWatch over its UART.  I mostly use it to quickly prototype
@@ -291,7 +291,7 @@ class GoodWatch:
         #Get the reply.
         reply=self.serial.read(1);
         if len(reply)!=1:
-            print "Error, missing reply.";
+            print("Error, missing reply.");
             sys.exit(1);
         elif ord(reply[0])==0x00:
             #Success
@@ -304,8 +304,8 @@ class GoodWatch:
             #assert(crc==self.crc(rep));
             return rep;
         else:
-            print "Error 0x%02x in reply to 0x%02x." % (
-                ord(reply[0]), ord(msg[0]));
+            print("Error 0x%02x in reply to 0x%02x." % (
+                ord(reply[0]), ord(msg[0])));
             #Not sure whether data is coming, so grab a chunk just in case.
             self.serial.read(10);
     def turbomode(self,enable=1):
@@ -344,13 +344,13 @@ class GoodWatch:
         """Returns the DMESG buffer."""
         return self.transact("\x04");
     def randint(self,count):
-	"""Returns count random 16bit integers. """
-	import struct
-	
-	samples=();
+        """Returns count random 16bit integers. """
+        import struct
+
+        samples=();
         while count>0:
             n=min(4,count);
-	    samples=samples+struct.unpack("<"+"H"*n,self.transact("\x05\x00"+chr16(n)));
+            samples=samples+struct.unpack("<"+"H"*n,self.transact("\x05\x00"+chr16(n)));
             count=count-n;
         return samples;
     
@@ -429,71 +429,71 @@ if __name__=='__main__':
     try:
         goodwatch.turbomode();
     except:
-        print "turbo error."
+        print( "turbo error.");
 
     if args.peek!=None:
         adr=int(args.peek,16);
         val=goodwatch.peek(adr);
-        print "0x%04x: %04x\n" % (adr,val);
+        print("0x%04x: %04x\n" % (adr,val));
 
     if args.lcd!=None:
         goodwatch.lcdstring(args.lcd);
 
     if args.dmesg>0:
-        print goodwatch.dmesg();
+        print(goodwatch.dmesg());
     if args.randint != None:
         samples=goodwatch.randint(int(args.randint));
-        print "%04x "*len(samples)%samples
+        print("%04x "*len(samples)%samples);
     if args.randdump != None:
-        print "Fetching samples."
+        print("Fetching samples.");
         samples=goodwatch.randint(1024);
         f=open(args.randdump,'w');
         for s in samples:
             f.write("%d, %d\n" % (s>>8, s&0xFF));
 
     if args.beacon!=None:
-        print "Turning radio on.";
+        print("Turning radio on.");
         goodwatch.radioonoff(1);
-        print "Configuring radio.";
+        print("Configuring radio.");
         goodwatch.radioconfig(beaconconfig);
         goodwatch.radiofreq(433.0);
         while 1:
-            print "Transmitting: %s" % args.beacon;
+            print("Transmitting: %s" % args.beacon);
             goodwatch.radiotx(args.beacon+"\x00");
             time.sleep(1);
 
     if args.ook!=None:
-        print "Turning radio on.";
+        print("Turning radio on.");
         goodwatch.radioonoff(1);
         time.sleep(1);
-        print "Configuring radio.";
+        print("Configuring radio.");
         goodwatch.radioconfig(beaconconfig);
         goodwatch.radioconfig(ookconfig);
         #Docs say 433.920, but there's a lot of drift.
         goodwatch.radiofreq(433.920);
         while 1:
-            print "Transmitting packet %d" % int(args.ook);
+            print("Transmitting packet %d" % int(args.ook));
             goodwatch.radiotx(ookpackets[int(args.ook)].decode('hex'));
             time.sleep(0.1);
             
     if args.pocsagtx!=None:
-        print "WARNING: POCSAG DOESN'T WORK YET";
+        print("WARNING: POCSAG DOESN'T WORK YET");
         time.sleep(1);
         goodwatch.radioonoff(1);
-        print "Configuring radio.";
+        print("Configuring radio.");
         goodwatch.radioconfig(beaconconfig);
         goodwatch.radioconfig(pocsagconfig);
         #Standard DAPNET frequency.
         goodwatch.radiofreq(439.988);
         while 1:
-            print "Transmitting packet.";
+            print("Transmitting packet.");
             goodwatch.radiotx(pocsagpacket.decode('hex'),32);
             time.sleep(1);
     if args.pocsag!=None:
         #print "WARNING: POCSAG DOESN'T WORK YET";
         time.sleep(1);
         goodwatch.radioonoff(1);
-        print "Configuring radio.";
+        print("Configuring radio.");
         #goodwatch.radioconfig(beaconconfig);
         goodwatch.radioconfig(pocsagconfig);
         #Standard DAPNET frequency.
@@ -501,20 +501,20 @@ if __name__=='__main__':
         while 1:
             pkt=goodwatch.radiorx();
             if len(pkt)>1: # and pkt[0]=='\xea' and pkt[1]=='\x27':
-                print pkt.encode('hex');
+                print(pkt.encode('hex'));
             time.sleep(0.1);
     
     if args.beaconsniff!=None:
-        print "Turning radio on.";
+        print("Turning radio on.");
         goodwatch.radioonoff(1);
-        print "Configuring radio.";
+        print("Configuring radio.");
         goodwatch.radioconfig(beaconconfig);
         goodwatch.radiofreq(433.0);
         while 1:
             packet=goodwatch.radiorx();
             p=stripnulls(packet);
             if len(p)>1:
-                print p;
+                print(p);
             time.sleep(1);
             
         


### PR DESCRIPTION
Building on #132, I think this produces the same list of bytes that it does in python2, but again, I have no hardware to test on (yet!)

One oddity I noticed (being no expert on CRCs) is that the actual number computed in the CRC function is quite large before the last 2 bytes are taken, which prevented me from using `crc.to_bytes(2, byteorder='little')`.