### PR TITLE
Add swatch internet time (beats) app 

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -17,6 +17,7 @@ COUNTER_APP = 1
 DMESG_APP = 0
 PAGER_APP = 0
 JUKEBOX_APP = 1
+BEATS_APP=0
 
 
 #set default flashing serial port, dont override if passed in as an argument
@@ -97,6 +98,11 @@ ifeq ($(JUKEBOX_APP),1)
 APPS_OBJ += apps/jukebox.o
 APPS_DEFINES += JUKEBOX_APP 
 endif
+ifeq ($(BEATS_APP),1)
+APPS_OBJ += apps/beats.o
+APPS_DEFINES += BEATS_APP
+endif
+
 
 
 #GCC8 from Texas Instruments, not the GCC4 that ships with Debian.
@@ -108,7 +114,7 @@ modules=rtcasm-r12.o main.o lcd.o lcdtext.o rtc.o  keypad.o bcd.o apps.o\
 	applist.o adc.o ref.o codeplugstr.o \
 	sidebutton.o power.o uart.o monitor.o ucs.o buzz.o \
 	radio.o packet.o dmesg.o codeplug.o rng.o descriptor.o \
-	optim.o libs/assembler.o libs/morse.o libs/pocsag.o \
+	optim.o libs/assembler.o libs/morse.o libs/pocsag.o libs/beats.o \
 	printf.o
 
 apps= $(APPS_OBJ)

--- a/firmware/applist.c
+++ b/firmware/applist.c
@@ -174,8 +174,14 @@ const struct app subapps[]={
   },
 #endif
   
+#ifdef BEATS_APP
+  {
+    .name="beats",
+    .draw=beats_draw, .init=beats_init, .exit=beats_exit,
+    .keypress=beats_keypress
+  },
+#endif
 
   //End on null entry.
   {.name=0, .init=0, .draw=0, .exit=0} 
 };
-

--- a/firmware/applist.c
+++ b/firmware/applist.c
@@ -178,7 +178,7 @@ const struct app subapps[]={
   {
     .name="beats",
     .draw=beats_draw, .init=beats_init, .exit=beats_exit,
-    .keypress=beats_keypress
+    .keypress=beats_keypress, .fallthrough=beats_fallthrough_keypress
   },
 #endif
 

--- a/firmware/applist.h
+++ b/firmware/applist.h
@@ -20,6 +20,7 @@ extern const struct app clock_applet;
 #include "apps/shabbat.h"
 #include "apps/hebrew.h"
 #include "apps/dmesg.h"
+#include "apps/beats.h"
 
 //Then radio apps.
 #include "apps/morse.h"

--- a/firmware/apps/beats.c
+++ b/firmware/apps/beats.c
@@ -8,7 +8,12 @@
 #include "libs/beats.h"
 #include <stdio.h>
 
-int ticks;
+#define CURRENT_UTC_OFFSET 4
+
+static int ticks;
+static int setting_offet=0;
+
+static int16_t utc_offset = CURRENT_UTC_OFFSET;
 
 //! Initialize the beats.
 void beats_init() {
@@ -20,17 +25,28 @@ int beats_exit() {
     return 0;
 };
 
-//! Draw the beats.
-void beats_draw() {
+static void draw_setting_offset() {
+    lcd_cleardigit(7);
+    lcd_char(6, 'u');
+    lcd_char(5, 't');
+    lcd_char(4, 'c');
+    lcd_cleardigit(3);
+    lcd_char(2, utc_offset > -1 ? ' ' : '-');
+    uint16_t unsigned_offset = utc_offset > 0 ? utc_offset : (0 - utc_offset);
+    lcd_digit(1, (unsigned_offset / 10) % 10);
+    lcd_digit(0, unsigned_offset % 10);
+}
+
+static void draw_beats(int forced) {
     ticks++;
     // don't re-draw unless 30 seconds have passed
     // a "beat" is 86.4 seconds but I can't think of a good way to keep track
     // of how far along we are in a beat
-    if (ticks < 4 * 30 && ticks != 0) {
+    if (!forced && ticks < 4 * 30 && ticks != 0) {
         return;
     }
     ticks = 0;
-    uint16_t beats = clock2beats(RTCHOUR, RTCMIN, RTCSEC);
+    uint16_t beats = clock2beats(RTCHOUR, RTCMIN, RTCSEC, utc_offset);
    
     lcd_digit(7, (beats / 100) % 10);
     lcd_digit(6,(beats / 10) % 10);
@@ -42,7 +58,34 @@ void beats_draw() {
     lcd_char(0, 's');
 };
 
+//! Draw the beats.
+void beats_draw(int forced) {
+    if(sidebutton_set()){
+        setting_offet=!setting_offet;
+        forced = 1;
+    }
+
+    if (setting_offet) {
+        draw_setting_offset();
+    } else {
+        draw_beats(forced);
+    }
+}
+
 //! A button has been pressed for the beats.
 int beats_keypress(char ch) {
-    return 1;
+    if(setting_offet) {
+        switch(ch) {
+        case '-':
+            utc_offset--;
+            return 1;
+        case '+':
+            utc_offset++;
+            return 1;
+        default:
+            return 0;
+        }
+    } else {
+        return 0;
+    }
 };

--- a/firmware/apps/beats.c
+++ b/firmware/apps/beats.c
@@ -89,3 +89,12 @@ int beats_keypress(char ch) {
         return 0;
     }
 };
+
+//! A button has been pressed in fallthrough mode
+int beats_fallthrough_keypress(char ch) {
+    if(ch == '1') {
+        beats_draw(1);
+    }
+
+    return 1;
+}

--- a/firmware/apps/beats.c
+++ b/firmware/apps/beats.c
@@ -1,0 +1,48 @@
+/*! \file beats.h
+  \brief Beats Application
+  
+*/
+
+#include <msp430.h>
+#include "api.h"
+#include "libs/beats.h"
+#include <stdio.h>
+
+int ticks;
+
+//! Initialize the beats.
+void beats_init() {
+    ticks = -1;
+
+};
+//! Exit to the next application.
+int beats_exit() {
+    return 0;
+};
+
+//! Draw the beats.
+void beats_draw() {
+    ticks++;
+    // don't re-draw unless 30 seconds have passed
+    // a "beat" is 86.4 seconds but I can't think of a good way to keep track
+    // of how far along we are in a beat
+    if (ticks < 4 * 30 && ticks != 0) {
+        return;
+    }
+    ticks = 0;
+    uint16_t beats = clock2beats(RTCHOUR, RTCMIN, RTCSEC);
+   
+    lcd_digit(7, (beats / 100) % 10);
+    lcd_digit(6,(beats / 10) % 10);
+    lcd_digit(5, (beats % 10));
+    lcd_cleardigit(4); //Space
+    lcd_cleardigit(3); //Space
+    lcd_char(2, 'b');
+    lcd_char(1, 't');
+    lcd_char(0, 's');
+};
+
+//! A button has been pressed for the beats.
+int beats_keypress(char ch) {
+    return 1;
+};

--- a/firmware/apps/beats.h
+++ b/firmware/apps/beats.h
@@ -12,3 +12,6 @@ void beats_draw();
 
 //! A button has been pressed for the beats.
 int beats_keypress(char ch);
+
+//! A button has been pressed in fallthrough mode
+int beats_fallthrough_keypress(char ch);

--- a/firmware/apps/beats.h
+++ b/firmware/apps/beats.h
@@ -1,0 +1,14 @@
+/*! \file beats.h
+  \brief Beats Application
+  
+*/
+
+//! Initialize the beats.
+void beats_init();
+//! Exit to the next application.
+int beats_exit();
+//! Draw the beats.
+void beats_draw();
+
+//! A button has been pressed for the beats.
+int beats_keypress(char ch);

--- a/firmware/libs/.gitignore
+++ b/firmware/libs/.gitignore
@@ -2,3 +2,4 @@ assembler
 pocsag
 hebrew
 jukebox
+beats

--- a/firmware/libs/Makefile
+++ b/firmware/libs/Makefile
@@ -1,13 +1,14 @@
 # This is just for testing the libraries.  They are build with
 # firmware/Makefile when running in the watch.
 
-EXECS= assembler pocsag jukebox hebrew
+EXECS= assembler pocsag jukebox hebrew beats
 
 run: all
 	./assembler
 	./pocsag
 	./jukebox
 	./hebrew
+	./beats
 
 clean:
 	rm -rf *.o $(EXECS)
@@ -26,3 +27,5 @@ jukebox: jukebox.c jukebox.h
 hebrew: hebrew.c hebrew.h
 	$(CC) -Werror -DSTANDALONE -o hebrew $<
 
+beats: beats.c beats.h
+	$(CC) -Werror -DSTANDALONE -o beats $<

--- a/firmware/libs/beats.c
+++ b/firmware/libs/beats.c
@@ -10,13 +10,11 @@
 
 #include <stdint.h>
 
-#define UTC_OFFSET 4
-
-uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds) {
+uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds, int16_t utc_offset) {
     uint32_t beats = seconds;
     beats += 60 * minutes;
     beats += (uint32_t)hours * 60 * 60; //explicit hour cast to work with 16-bit MSP430 arch
-    beats += (UTC_OFFSET + 1) * 60 * 60; // offset from utc + 1 since beats in in UTC+1
+    beats += (utc_offset + 1) * 60 * 60; // offset from utc + 1 since beats in in UTC+1
 
     beats /= 86.4; // convert to beats
     beats %= 1000; // truncate to 3 digits for overflow
@@ -29,6 +27,8 @@ uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds) {
 #include <stdio.h>
 #include <time.h>
 
+#define UTC_OFFSET 4
+
 int main(void) {
     time_t rawtime;
     struct tm * timeinfo;
@@ -36,8 +36,7 @@ int main(void) {
     time(&rawtime);
     timeinfo = localtime(&rawtime);
     printf("Current local time and date: %s", asctime(timeinfo));
-    printf("%u\n", timeinfo->tm_hour);
-    uint16_t beats = clock2beats(timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
+    uint16_t beats = clock2beats(timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, UTC_OFFSET);
     printf("@%u\n", beats);
 }
 

--- a/firmware/libs/beats.c
+++ b/firmware/libs/beats.c
@@ -1,0 +1,44 @@
+/*! \file beats.c
+  \brief Swatch Internet Time (aka beats) library
+  
+  Convert standard time to swatch internet time, which is a metric time system that divides each
+  mean solar day into 1000 "beats". This code counts the number of seconds since midnight UTC+1.
+  It's a bit lossy because each "beat" is 86.4 seconds, but oh well
+
+  https://en.wikipedia.org/wiki/Swatch_Internet_Time
+*/
+
+#include <stdint.h>
+
+#define UTC_OFFSET 4
+
+uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds) {
+    uint32_t beats = seconds;
+    beats += 60 * minutes;
+    beats += (uint32_t)hours * 60 * 60; //explicit hour cast to work with 16-bit MSP430 arch
+    beats += (UTC_OFFSET + 1) * 60 * 60; // offset from utc + 1 since beats in in UTC+1
+
+    beats /= 86.4; // convert to beats
+    beats %= 1000; // truncate to 3 digits for overflow
+
+    return (uint16_t) beats;
+}
+
+#ifdef STANDALONE
+
+#include <stdio.h>
+#include <time.h>
+
+int main(void) {
+    time_t rawtime;
+    struct tm * timeinfo;
+
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
+    printf("Current local time and date: %s", asctime(timeinfo));
+    printf("%u\n", timeinfo->tm_hour);
+    uint16_t beats = clock2beats(timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
+    printf("@%u\n", beats);
+}
+
+#endif

--- a/firmware/libs/beats.h
+++ b/firmware/libs/beats.h
@@ -1,0 +1,11 @@
+/*! \file beats.h
+  \brief Swatch Internet Time (aka beats) library
+  
+  Convert standard time to swatch internet time, which is a metric time system that divides each
+  mean solar day into 1000 "beats". This code counts the number of seconds since midnight UTC+1.
+  It's a bit lossy because each "beat" is 86.4 seconds, but oh well
+
+  https://en.wikipedia.org/wiki/Swatch_Internet_Time
+*/
+
+uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds);

--- a/firmware/libs/beats.h
+++ b/firmware/libs/beats.h
@@ -8,4 +8,4 @@
   https://en.wikipedia.org/wiki/Swatch_Internet_Time
 */
 
-uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds);
+uint16_t clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds, int16_t utc_offset);


### PR DESCRIPTION
[Swatch internet time](https://en.wikipedia.org/wiki/Swatch_Internet_Time) is a time keeping system that divides the mean solar day into 1000 beats for a more sensible time system. It also gets rid of timezones, everything is relative to UTC+1. This here app lets the goodwatch show the current time in beats