### PR TITLE
Jukebox Applet Fall-through Buttons

### DIFF
--- a/bin/batterylife.py
+++ b/bin/batterylife.py
@@ -14,6 +14,7 @@ capacity=100 #mAH
 
 ampsum=0.0;
 ampcount=0;
+lastamp=0;
 
 #Ugly shotgun parser to ignore comments and early records.
 for line in sys.stdin:
@@ -22,7 +23,7 @@ for line in sys.stdin:
     else:
         words=line.split();
         time=float(words[0]);
-        amps=float(words[1]);
+        lastamp=amps=float(words[1]);
         milliamps=amps*1000.0;
 
         #We only count after the first 20 seconds, as booting takes 5 to 10 seconds.
@@ -31,6 +32,8 @@ for line in sys.stdin:
             ampsum=ampsum+amps;
 
 if ampcount>0:
+    microamp=lastamp*1000000.0;
+    print("%f µA final consumption"%microamp);
     ampavg=ampsum/(ampcount*1.0);
     milliamp=ampavg*1000.0;
     microamp=ampavg*1000000.0;

--- a/firmware/applist.c
+++ b/firmware/applist.c
@@ -22,7 +22,7 @@ const struct app setting_applet=
 const struct app apps[]={
   //Clock
   {.name="clock", .init=clock_init, .draw=clock_draw, .exit=clock_exit,
-   .keypress=clock_keypress
+   .keypress=clock_keypress, .packettx=clock_packettx
   },
 
 #ifdef STOPWATCH_APP
@@ -45,7 +45,6 @@ const struct app apps[]={
    the main menu once selected.
  */
 const struct app subapps[]={
-
 
 #ifdef RPN_APP
   //RPN Calculator
@@ -94,9 +93,6 @@ const struct app subapps[]={
 #ifdef HEBREW_APP
   //Hebrew Calendar applet.  Falls through so that it can run from the clock.
   {.name="hebrew", .fallthrough=hebrew_keypress
-   //.init=hebrew_init, .draw=hebrew_draw, .exit=hebrew_exit,
-   //.keypress=hebrew_keypress,
-   
   },
 #endif
 
@@ -160,7 +156,8 @@ const struct app subapps[]={
   {.name="JUKEBOX",
    .init=jukebox_init, .draw=jukebox_draw, .exit=jukebox_exit,
    .packetrx=jukebox_packetrx, .packettx=jukebox_packettx,
-   .keypress=jukebox_keypress
+   .keypress=jukebox_keypress,
+   .fallthrough=jukebox_fallthrough
   },
 #endif
 

--- a/firmware/apps/clock.c
+++ b/firmware/apps/clock.c
@@ -313,3 +313,9 @@ int clock_keypress(char ch){
   }
   return 1;
 }
+
+//Forwards a packet to the submenu app.
+void clock_packettx(){
+  submenu_packettx();
+}
+

--- a/firmware/apps/clock.h
+++ b/firmware/apps/clock.h
@@ -19,3 +19,6 @@ void clock_playtime(int hold);
 void draw_time(int redraw);
 //! Draw the date.
 void draw_date();
+
+//! Callback after transmission.
+void clock_packettx();

--- a/firmware/apps/jukebox.c
+++ b/firmware/apps/jukebox.c
@@ -131,7 +131,6 @@ void jukebox_init() {
 	if (!has_radio) {
 		app_next();
 	}
-	printf("10 button entries are available for Jukebox.\n");
 	lcd_string(pinChar); // Draw screen
 }
 
@@ -274,7 +273,7 @@ uint8_t* build_jukebox_packet(int cmd, int pin) {
  */
 
 void jukebox_packetrx(uint8_t *packet, int len) {
-	printf("Not yet supported.\n");
+  //printf("Not yet supported.\n");
 }
 
 /*================================= U I =================================*/
@@ -303,17 +302,21 @@ void pinInput() {
 	lcd_string(pinChar); // Update screen
 }
 
+//Quick little function to set up for a transmission.
+static void jukebox_configradio(){
+  // Radio Settings
+  radio_on();
+  radio_writesettings(jukebox_settings);
+  radio_writepower(0xB0);
+  radio_setfreq(433920000); // 433.92MHz
+}
+
 // Keypress Handler
 int jukebox_keypress(char ch) {
 	if (pinFlag && (lastch = ch) && ch >= '0' && ch <= '9') {
 		pinInput();
 	} else if (!pinFlag && (lastch = ch) && ch >= '0' && ch <= '9') {
-		// Radio Settings
-		radio_on();
-		radio_writesettings(jukebox_settings);
-		radio_writepower(0xB0);
-		radio_setfreq(433920000); // 433.92MHz
-
+	        jukebox_configradio();
 		//This handler will be called back as the packet finished transmission.
 		jukebox_packettx();
 	} else if (!pinFlag) {
@@ -325,8 +328,39 @@ int jukebox_keypress(char ch) {
 	return 0;
 }
 
-// Button Mapping
+// Fallthrough keypress Handler
+int jukebox_fallthrough(char ch) {
+  //Here we substitute characters so that the fallthrough row sends
+  //useful commands.
+  switch(ch){
+  case '1': //Pause
+    lastch='1';
+    break;
+  case '3': //Power
+    lastch='7';
+    break;
+  case '-': //Skip
+    lastch='0';
+    break;
+  default:
+    lastch=0;
+    break;
+  }
 
+  
+  if(lastch){
+    jukebox_configradio();
+    jukebox_packettx();
+  }else{
+    //On a keyup, make sure the radio is off.
+    radio_off();
+  }
+  
+  return 0;
+}
+
+
+// Button Mapping
 void jukebox_packettx() {
 	if (lastch <= '9' && lastch >= '0') {
 		switch (lastch - '0') {

--- a/firmware/apps/jukebox.h
+++ b/firmware/apps/jukebox.h
@@ -3,13 +3,13 @@
  * Author: NotPike
  */
 
-//! Enter the OOK application.
+//! Enter the Jukebox application.
 void jukebox_init();
 
-//! Exit the OOK application.
+//! Exit the Jukebox application.
 int jukebox_exit();
 
-//! Draw the OOK screen.
+//! Draw the Jukebox screen.
 void jukebox_draw();
 
 //! Handle an incoming packet.
@@ -18,8 +18,10 @@ void jukebox_packetrx(uint8_t *packet, int len);
 //! Callback after transmission.
 void jukebox_packettx();
 
-//! Keypress handler for the OOK applet.
+//! Keypress handler for the Jukebox applet.
 int jukebox_keypress(char ch);
+//! Fallthrough handler for the Jukebox applet.
+int jukebox_fallthrough(char ch);
 
 //! NEC Encoder
 void encode(uint8_t *out, uint8_t command, int pin);

--- a/firmware/apps/submenu.c
+++ b/firmware/apps/submenu.c
@@ -84,3 +84,12 @@ int submenu_fallthrough(char ch){
   //Return 1 if there is no handler, so tha the screen is redrawn.
   return 1;
 }
+
+
+//! Lets a keypress fall through from the clock to the select submenu applet.
+void submenu_packettx(){
+  /* Call the fallthrough function if it exists.
+   */
+  if(subapps[subindex].packettx)
+    subapps[subindex].packettx();
+}

--- a/firmware/apps/submenu.h
+++ b/firmware/apps/submenu.h
@@ -14,3 +14,10 @@ int submenu_exit();
 
 //! Enter the submenu.
 void submenu_init();
+
+
+//! Fall through to the submenu for the third row.
+int submenu_fallthrough(char ch);
+
+//! Fall through to the submenu app for a transmission.
+void submenu_packettx();


### PR DESCRIPTION
Since the [Jukebox](https://github.com/travisgoodspeed/goodwatch/wiki/Jukebox) app was first written by @notpike, the third row of buttons has become a "fall-through" row, which calls the submenu applet if pressed from the clock.  This is mostly used by the Hebrew calendar and the Beats clock, but it could also be handy if you want to be able to skip songs at the bar with one press from the clock and no mode switch.

I've power profiled this to make sure that the radio is turned off, and the code looks right.  I'll try it out on a real jukebox before merging.

- [ ] Test on a real jukebox.
- [x] Pin selection is persistent, only changed from `000` with Set button.