### PR TITLE
RF Test Mode

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -8,15 +8,15 @@ HEX_APP = 1
 STOPWATCH_APP = 1
 PHRASE_APP = 0
 HEBREW_APP = 1
-SHABBAT_APP = 1
-RNG_APP = 1
+SHABBAT_APP = 0
+RNG_APP = 0
 TUNER_APP = 0
 MORSE_APP = 0
 BEACON_APP = 0
 OOK_APP = 1
-SHADERS_APP = 1
+SHADERS_APP = 0
 COUNTER_APP = 1
-DMESG_APP = 0
+DMESG_APP = 1
 PAGER_APP = 0
 JUKEBOX_APP = 1
 
@@ -122,7 +122,7 @@ CC = msp430-elf-gcc -minrt -msmall -mmcu=cc430f6137 -Wall -I. -I/opt/msp430-gcc-
 
 BSL = ../bin/cc430-bsl.py -r 38400 -p $(PORT)
 
-modules=rtcasm-r12.o main.o lcd.o lcdtext.o rtc.o  keypad.o bcd.o apps.o\
+modules=rtcasm-r12.o lcd.o lcdtext.o rtc.o  keypad.o bcd.o apps.o\
 	applist.o adc.o ref.o codeplugstr.o \
 	sidebutton.o power.o uart.o monitor.o ucs.o buzz.o \
 	radio.o packet.o dmesg.o codeplug.o rng.o descriptor.o \
@@ -141,12 +141,16 @@ buildtime.h:
 	../bin/buildtime.py >buildtime.h
 
 goodwatch.elf: $(modules) $(apps) *.h  
-	#$(CC) -T msp430.x -o goodwatch.elf $(modules) $(apps)
-	$(CC)  -T cc430f6137.ld -o goodwatch.elf $(modules) $(apps)
+	$(CC)  -T cc430f6137.ld -o goodwatch.elf main.c $(modules) $(apps)
 	../bin/printsizes.py goodwatch.elf || echo "Please install python-pyelftools."
+rftest.elf: $(modules) $(apps) *.h  
+	$(CC) -DRFTEST  -T cc430f6137.ld -o rftest.elf main.c $(modules) $(apps)
+	../bin/printsizes.py rftest.elf || echo "Please install python-pyelftools."
 
 goodwatch.hex: goodwatch.elf
 	msp430-elf-objcopy -O ihex goodwatch.elf goodwatch.hex
+rftest.hex: rftest.elf
+	msp430-elf-objcopy -O ihex rftest.elf rftest.hex
 
 clean:
 	rm -rf *~ */*~ *.hex *.elf *.o */*.o goodwatch githash.h buildtime.h html latex goodwatch.elf energytrace.png energytrace.txt codeplugstr.c dmesg.bin
@@ -155,6 +159,8 @@ erase:
 	$(BSL) -e
 sbwflash: goodwatch.hex codeplug.hex
 	mspdebug tilib "prog goodwatch.elf" "load codeplug.hex"
+sbwrftest: rftest.hex codeplug.hex
+	mspdebug tilib "prog rftest.elf" "load codeplug.hex"
 
 flash: goodwatch.hex
 	$(BSL) -ef goodwatch.hex

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -140,6 +140,22 @@ int main(void) {
   WDTCTL = WDT_ADLY_250;
   SFRIE1 |= WDTIE;
 
+
+  //'make sbwrftest' will flash an image that beacons repeatedly in
+  //Morse, to test the RF chain.
+#ifdef RFTEST
+  lcd_string("RFTEST");
+  radio_on();
+  radio_writesettings(0);
+  radio_writepower(0x25);
+  //codeplug_setfreq();
+  radio_setfreq(433920000);
+  radio_strobe(RF_SCAL);
+  while(1)
+    radio_morse("      GOODWATCH  RFTEST " CALLSIGN " " CALLSIGN);
+#endif
+  
+
   printf("Booted.\n");
   __bis_SR_register(LPM3_bits + GIE);        // Enter LPM3
   while(1){


### PR DESCRIPTION
`make sbwrftest` will transmit now a test pattern as CW on 433.92 MHz, to verify that the RF chain has been properly soldered before encasing the watch.

The also changes the default app collection:
1. Shabbat mode is now disabled.  (Hebrew calendar remains enabled.)
2. RNG is now disabled.
3. Shaders is now disabled.
4. Dmesg is now enabled.