### PR TITLE
Remove deprecated -minrt flag with GCC9

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -118,7 +118,7 @@ endif
 
 
 #GCC8 from Texas Instruments, not the GCC4 that ships with Debian.
-CC = msp430-elf-gcc -minrt -msmall -mmcu=cc430f6137 -Wall -I. -I/opt/msp430-gcc-support-files/include -Os  $(addprefix -D, $(APPS_DEFINES)) -Wl,--gc-sections,--print-gc-sections -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables -flto
+CC = msp430-elf-gcc -msmall -mmcu=cc430f6137 -Wall -I. -I/opt/msp430-gcc-support-files/include -Os  $(addprefix -D, $(APPS_DEFINES)) -Wl,--gc-sections,--print-gc-sections -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables -flto
 
 BSL = ../bin/cc430-bsl.py -r 38400 -p $(PORT)
 


### PR DESCRIPTION
Causes many deprecation warnings during build tested with `msp430-gcc-9.3.1.11_linux64`

```
msp430-elf-gcc: warning: '-minrt' is deprecated
```

Final binary on GCC 9:

```
goodwatch.elf:
        24624 bytes of .text, 3286 bytes of .rodata (85% Flash)
        30 bytes of .data, 752 bytes of .bss, 18 bytes of .noinit (19% RAM)
```

GCC 8 (tested on `msp430-gcc-8.3.1.25_linux64`) with and without `-minrt` both produce identical:

```
goodwatch.elf:
        25502 bytes of .text, 3438 bytes of .rodata (88% Flash)
        30 bytes of .data, 752 bytes of .bss, 18 bytes of .noinit (19% RAM)
```

So seems this was a useless flag, and GCC 9 has better optimizations anyway.